### PR TITLE
Replace : gmail logo to google logo

### DIFF
--- a/src/shared/ui/icons.tsx
+++ b/src/shared/ui/icons.tsx
@@ -1,5 +1,5 @@
 // TODO: Consider using icons from lucide or use the svg directly
-import { SiGithub, SiGmail } from "@icons-pack/react-simple-icons";
+import { SiGithub, SiGmail , SiGoogle } from "@icons-pack/react-simple-icons";
 import {
   AlertTriangle,
   Archive,
@@ -55,6 +55,7 @@ export {
   Filter as FilterIcon,
   SiGithub as GithubIcon,
   SiGmail as GmailIcon,
+  SiGoogle as GoogleIcon,
   Heart as HeartListIcon,
   Info as InfoIcon,
   Layout as LayoutIcon,

--- a/src/widgets/auth-buttons.tsx
+++ b/src/widgets/auth-buttons.tsx
@@ -7,7 +7,7 @@ import {
 } from "~/features/auth/service-providers";
 
 import { Button } from "~/shared/ui/button";
-import { GithubIcon, GmailIcon } from "~/shared/ui/icons";
+import { GithubIcon, GmailIcon, GoogleIcon } from "~/shared/ui/icons";
 
 import JustTip from "./just-the-tip";
 
@@ -30,7 +30,7 @@ export default function AuthButton() {
           variant="outline"
           onClick={signInWithGoogle}
         >
-          <GmailIcon color="#EA4335" size={24} />
+          <GoogleIcon color="#EA4335" size={24} />
           <p className="tracking-wider">Google</p>
         </Button>
       </JustTip>


### PR DESCRIPTION
fixes #288 

## 📄 What does this PR do?

  Google login button had an Gmail logo that was incorrect , needed to be Google logo 
  
   Replaced: Gmail logo to Google logo 
 
## Screenshot 

Before :

<img width="586" height="91" alt="image" src="https://github.com/user-attachments/assets/0fec0b28-2e54-4895-9aba-3f0129a4924f" />

After:

<img width="640" height="85" alt="image" src="https://github.com/user-attachments/assets/d4d78606-3a98-433d-b28d-967556dac19b" />


## 📌 Why is this change necessary?

  - Fixes : UI bug , Button logo element was incorrect

## ✅ Checklist before merging

- [ ✅] My changes follow the project’s code style and guidelines
- [ ✅] I have tested my changes locally
- [ ✅] No console errors or warnings
- [ ] I’ve rebased with the latest `dev` branch
- [ ] I’ve added relevant comments and documentation where necessary
- [ ] I’ve updated unit or integration tests if required



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Google sign-in button to use the official Google icon, improving visual consistency and brand recognition.
  * Expanded the app’s icon set to include the Google icon for cohesive use across the interface.
  * Polished authentication UI without altering behavior or workflows.
  * Ensures a cleaner, more recognizable look for users interacting with Google-related actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->